### PR TITLE
Allow a redis URL to be set

### DIFF
--- a/lib/lita/standups/models/base.rb
+++ b/lib/lita/standups/models/base.rb
@@ -8,7 +8,10 @@ module Lita
         include Ohm::DataTypes
 
         def self.redis
-          Ohm.redis
+          # Password in the URL must only use URL safe characters
+          # This appears to be a bug in Ohm or Redic. 
+          @redic_url = ENV['REDIS_URL'] || 'redis://127.0.0.1:6379'
+          Ohm.redis = Redic.new(@redic_url)
         end
 
       end


### PR DESCRIPTION
Add support for using a remote redis host via the REDIS_HOST env var. This can include the Redis password, but apparently they must be URL safe passwords.